### PR TITLE
Integrate Mantine UI into layout and dashboard components

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,48 +1,183 @@
-import { unstable_setRequestLocale } from 'next-intl/server';
-import { getTranslations } from 'next-intl/server';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useSupabase } from '@/lib/hooks/useSupabase';
+import { DashboardLayout } from '@/components/dashboard/DashboardLayout';
+import { Grid, Paper, Text, Title, Group, RingProgress, Stack, Button } from '@mantine/core';
+import { IconBuilding, IconReceipt, IconUsers, IconPlus } from '@tabler/icons-react';
 import Link from 'next/link';
-import StoredPropertiesAlertWrapper from '@/components/properties/StoredPropertiesAlertWrapper';
 
-export default async function DashboardPage({
-	params: { locale },
-}: {
-	params: { locale: string };
-}) {
-	// Enable static rendering
-	unstable_setRequestLocale(locale);
+interface DashboardPageProps {
+	params: {
+		locale: string;
+	};
+}
 
-	const supabase = createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+export default function DashboardPage({ params: { locale } }: DashboardPageProps) {
+	const [loading, setLoading] = useState(true);
+	const router = useRouter();
+	const supabase = useSupabase();
+	const t = useTranslations('dashboard');
 
-	// Check if user is authenticated
-	if (!user) {
-		redirect(`/${locale}/login`);
+	useEffect(() => {
+		const checkAuth = async () => {
+			const { data: { session } } = await supabase.auth.getSession();
+			if (!session) {
+				router.push(`/${locale}/login`);
+			}
+			setLoading(false);
+		};
+
+		checkAuth();
+	}, [supabase.auth, router, locale]);
+
+	if (loading) {
+		return (
+			<DashboardLayout locale={locale}>
+				<Text>Loading...</Text>
+			</DashboardLayout>
+		);
 	}
 
-	const t = await getTranslations();
-
 	return (
-		<div className="min-h-screen bg-gray-50">
-			{/* Main content */}
-			<main className="container mx-auto px-4 py-8 sm:px-6">
-				<StoredPropertiesAlertWrapper locale={locale} />
-				<div className="bg-white shadow rounded-lg p-6">
-					<h2 className="text-lg font-medium text-gray-900 mb-4">
-						{t('dashboard.welcome')}
-					</h2>
-					<p className="text-gray-600">{t('dashboard.description')}</p>
-					<Link
+		<DashboardLayout locale={locale}>
+			<Stack gap="lg">
+				<Group justify="space-between" align="center">
+					<Title order={2}>{t('welcome')}</Title>
+					<Button
+						component={Link}
 						href={`/${locale}/dashboard/properties/new`}
-						className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+						leftSection={<IconPlus size="1.2rem" />}
 					>
-						{t('properties.new.title')}
-					</Link>
-				</div>
-			</main>
-		</div>
+						{t('addProperty')}
+					</Button>
+				</Group>
+
+				<Grid>
+					<Grid.Col span={{ base: 12, md: 4 }}>
+						<Paper p="md" radius="md" withBorder>
+							<Group>
+								<RingProgress
+									size={80}
+									roundCaps
+									thickness={8}
+									sections={[{ value: 75, color: 'blue' }]}
+									label={
+										<Text ta="center" size="xs" fw={700}>
+											75%
+										</Text>
+									}
+								/>
+								<Stack gap={0}>
+									<Text size="xl" fw={700}>12</Text>
+									<Text size="sm" c="dimmed">{t('propertiesOccupied')}</Text>
+								</Stack>
+							</Group>
+						</Paper>
+					</Grid.Col>
+
+					<Grid.Col span={{ base: 12, md: 4 }}>
+						<Paper p="md" radius="md" withBorder>
+							<Group>
+								<RingProgress
+									size={80}
+									roundCaps
+									thickness={8}
+									sections={[{ value: 60, color: 'green' }]}
+									label={
+										<Text ta="center" size="xs" fw={700}>
+											60%
+										</Text>
+									}
+								/>
+								<Stack gap={0}>
+									<Text size="xl" fw={700}>$24,500</Text>
+									<Text size="sm" c="dimmed">{t('monthlyExpenses')}</Text>
+								</Stack>
+							</Group>
+						</Paper>
+					</Grid.Col>
+
+					<Grid.Col span={{ base: 12, md: 4 }}>
+						<Paper p="md" radius="md" withBorder>
+							<Group>
+								<RingProgress
+									size={80}
+									roundCaps
+									thickness={8}
+									sections={[{ value: 90, color: 'orange' }]}
+									label={
+										<Text ta="center" size="xs" fw={700}>
+											90%
+										</Text>
+									}
+								/>
+								<Stack gap={0}>
+									<Text size="xl" fw={700}>45</Text>
+									<Text size="sm" c="dimmed">{t('activeTenants')}</Text>
+								</Stack>
+							</Group>
+						</Paper>
+					</Grid.Col>
+				</Grid>
+
+				<Grid>
+					<Grid.Col span={{ base: 12, md: 6 }}>
+						<Paper p="md" radius="md" withBorder>
+							<Stack gap="md">
+								<Group justify="space-between">
+									<Group gap="xs">
+										<IconBuilding size="1.2rem" />
+										<Title order={3}>{t('quickActions')}</Title>
+									</Group>
+								</Group>
+								<Group>
+									<Button
+										component={Link}
+										href={`/${locale}/dashboard/properties/new`}
+										variant="light"
+										leftSection={<IconPlus size="1.2rem" />}
+									>
+										{t('addProperty')}
+									</Button>
+									<Button
+										component={Link}
+										href={`/${locale}/dashboard/expenses/new`}
+										variant="light"
+										leftSection={<IconPlus size="1.2rem" />}
+									>
+										{t('addExpense')}
+									</Button>
+									<Button
+										component={Link}
+										href={`/${locale}/dashboard/tenants/new`}
+										variant="light"
+										leftSection={<IconPlus size="1.2rem" />}
+									>
+										{t('addTenant')}
+									</Button>
+								</Group>
+							</Stack>
+						</Paper>
+					</Grid.Col>
+
+					<Grid.Col span={{ base: 12, md: 6 }}>
+						<Paper p="md" radius="md" withBorder>
+							<Stack gap="md">
+								<Group justify="space-between">
+									<Group gap="xs">
+										<IconReceipt size="1.2rem" />
+										<Title order={3}>{t('recentActivity')}</Title>
+									</Group>
+								</Group>
+								<Text c="dimmed">{t('noRecentActivity')}</Text>
+							</Stack>
+						</Paper>
+					</Grid.Col>
+				</Grid>
+			</Stack>
+		</DashboardLayout>
 	);
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,10 +1,34 @@
-import { notFound } from 'next/navigation';
+import { MantineProvider, createTheme } from '@mantine/core';
 import { NextIntlClientProvider } from 'next-intl';
+import { notFound } from 'next/navigation';
 import { ReactNode } from 'react';
 import { locales, Locale } from '@/lib/i18n/config';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import { Header } from '@/components/layout/Header';
+import '@mantine/core/styles.css';
 import '../globals.css';
+
+const theme = createTheme({
+	primaryColor: 'blue',
+	colors: {
+		blue: [
+			'#E3F2FD',
+			'#BBDEFB',
+			'#90CAF9',
+			'#64B5F6',
+			'#42A5F5',
+			'#2196F3',
+			'#1E88E5',
+			'#1976D2',
+			'#1565C0',
+			'#0D47A1',
+		],
+	},
+	fontFamily: 'var(--font-body)',
+	headings: {
+		fontFamily: 'var(--font-headings)',
+	},
+});
 
 export function generateStaticParams() {
 	return locales.map((locale) => ({ locale }));
@@ -33,11 +57,17 @@ export default async function LocaleLayout({
 	}
 
 	return (
-		<NextIntlClientProvider locale={locale} messages={messages}>
-			<div className="flex flex-col min-h-screen">
-				<Header locale={locale} />
-				{children}
-			</div>
-		</NextIntlClientProvider>
+		<html lang={locale}>
+			<body>
+				<NextIntlClientProvider locale={locale} messages={messages}>
+					<MantineProvider theme={theme}>
+						<div className="flex flex-col min-h-screen">
+							<Header locale={locale} />
+							{children}
+						</div>
+					</MantineProvider>
+				</NextIntlClientProvider>
+			</body>
+		</html>
 	);
 }

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState } from 'react';
+import { AppShell, Burger, Group, UnstyledButton, Text, useMantineTheme, Divider, Stack } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconHome, IconBuilding, IconReceipt, IconUsers, IconSettings, IconLogout, IconUser } from '@tabler/icons-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { useSupabase } from '@/lib/hooks/useSupabase';
+
+interface NavbarLinkProps {
+	icon: React.ReactNode;
+	label: string;
+	active?: boolean;
+	onClick?(): void;
+	href: string;
+}
+
+function NavbarLink({ icon, label, active, onClick, href }: NavbarLinkProps) {
+	return (
+		<UnstyledButton
+			component={Link}
+			href={href}
+			onClick={onClick}
+			sx={(theme) => ({
+				display: 'block',
+				width: '100%',
+				padding: theme.spacing.xs,
+				borderRadius: theme.radius.sm,
+				color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+				backgroundColor: active ? theme.fn.variant({ variant: 'light', color: theme.primaryColor }).background : 'transparent',
+				'&:hover': {
+					backgroundColor: theme.fn.variant({ variant: 'light', color: theme.primaryColor }).background,
+				},
+			})}
+		>
+			<Group>
+				{icon}
+				<Text size="sm">{label}</Text>
+			</Group>
+		</UnstyledButton>
+	);
+}
+
+interface DashboardLayoutProps {
+	children: React.ReactNode;
+	locale: string;
+}
+
+export function DashboardLayout({ children, locale }: DashboardLayoutProps) {
+	const [opened, { toggle }] = useDisclosure();
+	const theme = useMantineTheme();
+	const pathname = usePathname();
+	const t = useTranslations('navigation');
+	const supabase = useSupabase();
+
+	const mainLinks = [
+		{ icon: <IconHome size="1.2rem" />, label: t('home'), href: `/${locale}/dashboard` },
+		{ icon: <IconBuilding size="1.2rem" />, label: t('properties'), href: `/${locale}/dashboard/properties` },
+		{ icon: <IconReceipt size="1.2rem" />, label: t('expenses'), href: `/${locale}/dashboard/expenses` },
+		{ icon: <IconUsers size="1.2rem" />, label: t('tenants'), href: `/${locale}/dashboard/tenants` },
+		{ icon: <IconSettings size="1.2rem" />, label: t('settings'), href: `/${locale}/dashboard/settings` },
+	];
+
+	const quickLinks = [
+		{ icon: <IconUser size="1.2rem" />, label: t('profile'), href: `/${locale}/dashboard/profile` },
+	];
+
+	const handleLogout = async () => {
+		await supabase.auth.signOut();
+		window.location.href = `/${locale}/login`;
+	};
+
+	const mainNavLinks = mainLinks.map((link) => (
+		<NavbarLink
+			{...link}
+			key={link.label}
+			active={pathname === link.href}
+		/>
+	));
+
+	const quickNavLinks = quickLinks.map((link) => (
+		<NavbarLink
+			{...link}
+			key={link.label}
+			active={pathname === link.href}
+		/>
+	));
+
+	return (
+		<AppShell
+			header={{ height: 60 }}
+			navbar={{
+				width: 300,
+				breakpoint: 'sm',
+				collapsed: { mobile: !opened },
+			}}
+			padding="md"
+		>
+			<AppShell.Header>
+				<Group h="100%" px="md" justify="space-between">
+					<Group>
+						<Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
+						<Text size="lg" fw={700}>{t('appName')}</Text>
+					</Group>
+					<Group>
+						<UnstyledButton
+							onClick={handleLogout}
+							sx={(theme) => ({
+								display: 'flex',
+								alignItems: 'center',
+								padding: theme.spacing.xs,
+								borderRadius: theme.radius.sm,
+								color: theme.colorScheme === 'dark' ? theme.colors.dark[0] : theme.black,
+								'&:hover': {
+									backgroundColor: theme.fn.variant({ variant: 'light', color: theme.primaryColor }).background,
+								},
+							})}
+						>
+							<Group gap="xs">
+								<IconLogout size="1.2rem" />
+								<Text size="sm">{t('logout')}</Text>
+							</Group>
+						</UnstyledButton>
+					</Group>
+				</Group>
+			</AppShell.Header>
+
+			<AppShell.Navbar p="md">
+				<AppShell.Section grow>
+					<Stack gap="xs">
+						{mainNavLinks}
+					</Stack>
+				</AppShell.Section>
+
+				<Divider my="sm" />
+
+				<AppShell.Section>
+					<Stack gap="xs">
+						{quickNavLinks}
+					</Stack>
+				</AppShell.Section>
+			</AppShell.Navbar>
+
+			<AppShell.Main>
+				{children}
+			</AppShell.Main>
+		</AppShell>
+	);
+} 

--- a/src/lib/hooks/useSupabase.ts
+++ b/src/lib/hooks/useSupabase.ts
@@ -1,0 +1,5 @@
+import { supabase } from '@/lib/supabase/client';
+
+export function useSupabase() {
+	return supabase;
+} 

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -16,12 +16,15 @@
 		"home": "Home",
 		"properties": "Properties",
 		"expenses": "Expenses",
+		"tenants": "Tenants",
 		"settings": "Settings",
 		"about": "About",
 		"privacy": "Privacy",
 		"terms": "Terms",
 		"contact": "Contact",
-		"profile": "Profile"
+		"profile": "Profile",
+		"logout": "Logout",
+		"dashboard": "Dashboard"
 	},
 	"about": {
 		"title": "About Bricks & Mortar",
@@ -112,8 +115,17 @@
 	},
 	"dashboard": {
 		"title": "Dashboard",
-		"welcome": "Welcome to Your Dashboard",
-		"description": "This is your main dashboard where you'll be able to manage your properties and track expenses."
+		"welcome": "Welcome to your Dashboard",
+		"description": "This is your main dashboard where you'll be able to manage your properties and track expenses.",
+		"propertiesOccupied": "Properties Occupied",
+		"monthlyExpenses": "Monthly Expenses",
+		"activeTenants": "Active Tenants",
+		"quickActions": "Quick Actions",
+		"recentActivity": "Recent Activity",
+		"noRecentActivity": "No recent activity to show",
+		"addProperty": "Add Property",
+		"addExpense": "Add Expense",
+		"addTenant": "Add Tenant"
 	},
 	"home": {
 		"hero": {


### PR DESCRIPTION
* Update layout to include MantineProvider with a custom theme.
* Refactor DashboardPage to use client-side rendering with hooks for authentication.
* Enhance dashboard UI with Mantine components, including Grid, Paper, and RingProgress for better visual representation of data.
* Add new translations for dashboard features in English.
* Improve user experience by implementing loading state during authentication check.